### PR TITLE
[SCRUM-146] 채용공고 valid type 업데이트 API 추가 및 valid type 가져오기 API 추가

### DIFF
--- a/src/main/java/com/www/goodjob/controller/JobController.java
+++ b/src/main/java/com/www/goodjob/controller/JobController.java
@@ -265,14 +265,14 @@ public class JobController {
     @DeleteMapping("/delete-one-job-valid-type")
     public ResponseEntity<?> deleteJobWithValidType(
             @RequestParam("jobId") Long jobId,
-            @RequestParam("validType") String validType,
+            @RequestParam("validType") Integer validType,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         if (userDetails == null) {
             throw new RuntimeException("인증되지 않은 사용자입니다. JWT를 확인하세요.");
         }
         try {
-            String message = jobService.deleteJob(jobId);
+            String message = jobService.deleteJobWithValidType(jobId ,validType);
 
             return ResponseEntity.ok(Map.of("message", message));
         } catch (Exception e) {

--- a/src/main/java/com/www/goodjob/controller/JobController.java
+++ b/src/main/java/com/www/goodjob/controller/JobController.java
@@ -2,6 +2,7 @@ package com.www.goodjob.controller;
 
 import com.www.goodjob.domain.User;
 import com.www.goodjob.dto.JobDto;
+import com.www.goodjob.dto.ValidJobDto;
 import com.www.goodjob.dto.JobSearchResponse;
 import com.www.goodjob.dto.RegionGroupDto;
 import com.www.goodjob.security.CustomUserDetails;
@@ -255,4 +256,46 @@ public class JobController {
                     .body(Map.of("error", e.getMessage()));
         }
     }
+
+
+    @Operation(summary = "특정 job 하나 삭제", description = "FastAPI 서버로 특정 job 하나 삭제 요청을 보냄." +
+            "해당 job에 대해 ES에서 vector 삭제 & RDB의 is_public을 0으로 설정" +
+            "실패 시, is_public은 다시 1로 롤백하는 로직 포함."+
+            "삭제시 삭제이유 valid type을 업데이트 함")
+    @DeleteMapping("/delete-one-job-valid-type")
+    public ResponseEntity<?> deleteJobWithValidType(
+            @RequestParam("jobId") Long jobId,
+            @RequestParam("validType") String validType,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new RuntimeException("인증되지 않은 사용자입니다. JWT를 확인하세요.");
+        }
+        try {
+            String message = jobService.deleteJob(jobId);
+
+            return ResponseEntity.ok(Map.of("message", message));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
+
+    @Operation(summary = "job +valid Type 함께 가져오는 함수" ,description= " ")
+    @GetMapping("/job-valid-type")
+    public ResponseEntity<?> getJobWithValidType(){
+        try{
+            List<ValidJobDto> JobList =jobService.findAllJobWithValidType();
+            return ResponseEntity.ok(JobList);
+        }
+        catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
+
+
+
 }

--- a/src/main/java/com/www/goodjob/domain/Job.java
+++ b/src/main/java/com/www/goodjob/domain/Job.java
@@ -19,8 +19,11 @@ public class Job {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 공고 고유 ID
 
-    @OneToMany(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true ,fetch =FetchType.LAZY)
     private List<JobRegion> jobRegions = new ArrayList<>();
+
+    @OneToOne(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true, fetch =FetchType.LAZY)
+    private JobValidType jobValidType = new JobValidType();
 
     @Column(name = "company_name")
     private String companyName;

--- a/src/main/java/com/www/goodjob/domain/JobValidType.java
+++ b/src/main/java/com/www/goodjob/domain/JobValidType.java
@@ -1,0 +1,24 @@
+package com.www.goodjob.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "job_valid_type")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JobValidType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; //
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id")
+    private Job job;
+
+    @Column(name = "valid_type")
+    private Integer validType;
+}

--- a/src/main/java/com/www/goodjob/dto/ValidJobDto.java
+++ b/src/main/java/com/www/goodjob/dto/ValidJobDto.java
@@ -1,0 +1,72 @@
+package com.www.goodjob.dto;
+
+import com.www.goodjob.domain.Job;
+import com.www.goodjob.domain.JobValidType;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class ValidJobDto {
+
+    private Long id;
+    private List<RegionDto> regions;
+    private String companyName;
+    private String title;
+    private String department;
+    private String requireExperience;
+    private String jobType;
+    private Integer jobValidType;
+    private String requirements;
+    private String preferredQualifications;
+    private String idealCandidate;
+    private String jobDescription;
+    private LocalDate applyStartDate;
+    private LocalDate applyEndDate;
+    private Boolean isPublic;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastUpdatedAt;
+    private LocalDateTime expiredAt;
+    private LocalDateTime archivedAt;
+    private String rawJobsText;
+    private String url;
+    private String favicon;
+    private String regionText;
+
+    public static ValidJobDto from(Job job) {
+        List<RegionDto> regions = RegionDto.fromJob(job);
+        JobValidType jobValidType = job.getJobValidType();
+        return ValidJobDto.builder()
+                .id(job.getId())
+                .regions(regions)
+                .companyName(job.getCompanyName())
+                .title(job.getTitle())
+                .department(job.getDepartment())
+                .requireExperience(job.getExperience())
+                .jobType(job.getJobType())
+                .requirements(job.getRequirements())
+                .preferredQualifications(job.getPreferredQualifications())
+                .idealCandidate(job.getIdealCandidate())
+                .jobDescription(job.getJobDescription())
+                .applyStartDate(job.getApplyStartDate())
+                .applyEndDate(job.getApplyEndDate())
+                .isPublic(job.getIsPublic())
+                .createdAt(job.getCreatedAt())
+                .lastUpdatedAt(job.getLastUpdatedAt())
+                .expiredAt(job.getExpiredAt())
+                .archivedAt(job.getArchivedAt())
+                .rawJobsText(job.getRawJobsText())
+                .url(job.getUrl())
+                .favicon(job.getFavicon())
+                .regionText(job.getRegionText())
+                .jobValidType(jobValidType != null ? jobValidType.getValidType() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/www/goodjob/dto/ValidJobDto.java
+++ b/src/main/java/com/www/goodjob/dto/ValidJobDto.java
@@ -17,55 +17,26 @@ import java.util.List;
 public class ValidJobDto {
 
     private Long id;
-    private List<RegionDto> regions;
     private String companyName;
     private String title;
-    private String department;
-    private String requireExperience;
-    private String jobType;
     private Integer jobValidType;
-    private String requirements;
-    private String preferredQualifications;
-    private String idealCandidate;
-    private String jobDescription;
-    private LocalDate applyStartDate;
-    private LocalDate applyEndDate;
     private Boolean isPublic;
     private LocalDateTime createdAt;
-    private LocalDateTime lastUpdatedAt;
-    private LocalDateTime expiredAt;
-    private LocalDateTime archivedAt;
-    private String rawJobsText;
+    private LocalDate applyEndDate;
     private String url;
-    private String favicon;
-    private String regionText;
+
 
     public static ValidJobDto from(Job job) {
         List<RegionDto> regions = RegionDto.fromJob(job);
         JobValidType jobValidType = job.getJobValidType();
         return ValidJobDto.builder()
                 .id(job.getId())
-                .regions(regions)
                 .companyName(job.getCompanyName())
                 .title(job.getTitle())
-                .department(job.getDepartment())
-                .requireExperience(job.getExperience())
-                .jobType(job.getJobType())
-                .requirements(job.getRequirements())
-                .preferredQualifications(job.getPreferredQualifications())
-                .idealCandidate(job.getIdealCandidate())
-                .jobDescription(job.getJobDescription())
-                .applyStartDate(job.getApplyStartDate())
-                .applyEndDate(job.getApplyEndDate())
                 .isPublic(job.getIsPublic())
                 .createdAt(job.getCreatedAt())
-                .lastUpdatedAt(job.getLastUpdatedAt())
-                .expiredAt(job.getExpiredAt())
-                .archivedAt(job.getArchivedAt())
-                .rawJobsText(job.getRawJobsText())
+                .applyEndDate(job.getApplyEndDate())
                 .url(job.getUrl())
-                .favicon(job.getFavicon())
-                .regionText(job.getRegionText())
                 .jobValidType(jobValidType != null ? jobValidType.getValidType() : null)
                 .build();
     }

--- a/src/main/java/com/www/goodjob/repository/JobRepository.java
+++ b/src/main/java/com/www/goodjob/repository/JobRepository.java
@@ -49,5 +49,12 @@ public interface JobRepository extends JpaRepository<Job, Long> {
             "LEFT JOIN FETCH jr.region " +
             "WHERE j.id IN :ids")
     List<Job> findByIdInWithRegion(@Param("ids") List<Long> ids);
+
+    @Query("SELECT DISTINCT j FROM Job j " +
+            "LEFT JOIN FETCH j.jobRegions jr " +
+            "LEFT JOIN FETCH jr.region " +
+            "LEFT JOIN FETCH j.jobValidType "
+                )
+    List<Job> findAllWithValidType();
 }
 

--- a/src/main/java/com/www/goodjob/repository/JobValidTypeRepository.java
+++ b/src/main/java/com/www/goodjob/repository/JobValidTypeRepository.java
@@ -1,0 +1,25 @@
+package com.www.goodjob.repository;
+
+import com.www.goodjob.domain.JobValidType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import java.util.List;
+
+@Repository
+public interface JobValidTypeRepository  extends JpaRepository<JobValidType, Long> {
+
+    @Modifying
+    @Transactional
+    @Query(value = """
+    INSERT INTO job_valid_type (job_id, valid_type)
+    VALUES (:jobId, :validType)
+    ON DUPLICATE KEY UPDATE valid_type = VALUES(valid_type)
+    """, nativeQuery = true)
+    void upsertJobValidType(@Param("jobId") Long jobId, @Param("validType") int validType);
+}

--- a/src/main/java/com/www/goodjob/service/JobService.java
+++ b/src/main/java/com/www/goodjob/service/JobService.java
@@ -3,10 +3,7 @@ package com.www.goodjob.service;
 import com.www.goodjob.domain.Job;
 import com.www.goodjob.domain.Region;
 import com.www.goodjob.domain.User;
-import com.www.goodjob.dto.JobDto;
-import com.www.goodjob.dto.JobSearchResponse;
-import com.www.goodjob.dto.RegionDto;
-import com.www.goodjob.dto.RegionGroupDto;
+import com.www.goodjob.dto.*;
 import com.www.goodjob.enums.ExperienceCategory;
 import com.www.goodjob.enums.JobTypeCategory;
 import com.www.goodjob.repository.JobRepository;
@@ -17,6 +14,7 @@ import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.InterfaceAddress;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -169,7 +167,6 @@ public class JobService {
                 .collect(Collectors.toList());
     }
 
-
     public String deleteJob(Long jobId) {
         String url = fastapiHost + "/delete-job?job_id=" + jobId;
         try {
@@ -178,5 +175,14 @@ public class JobService {
         } catch (Exception e) {
             throw new RuntimeException("FastAPI 요청 실패: " + e.getMessage(), e);
         }
+    }
+
+//    public String deleteJobWithValidType(Long jobId, Integer validType){
+//
+//    }
+
+    public List<ValidJobDto> findAllJobWithValidType() {
+        List<Job> jobList = jobRepository.findAllWithValidType();
+        return jobList.stream().map(ValidJobDto::from).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/www/goodjob/service/JobService.java
+++ b/src/main/java/com/www/goodjob/service/JobService.java
@@ -7,6 +7,7 @@ import com.www.goodjob.dto.*;
 import com.www.goodjob.enums.ExperienceCategory;
 import com.www.goodjob.enums.JobTypeCategory;
 import com.www.goodjob.repository.JobRepository;
+import com.www.goodjob.repository.JobValidTypeRepository;
 import com.www.goodjob.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,6 +28,7 @@ public class JobService {
     private final RegionRepository regionRepository;
     private final RestTemplate restTemplate;
     private final SearchLogService searchLogService;
+    private final JobValidTypeRepository jobValidTypeRepository;
 
     @Value("${FASTAPI_HOST}")
     private String fastapiHost;
@@ -177,9 +179,20 @@ public class JobService {
         }
     }
 
-//    public String deleteJobWithValidType(Long jobId, Integer validType){
-//
-//    }
+    public String deleteJobWithValidType(Long jobId, Integer validType){
+
+        try{
+            if(validType !=0){
+                deleteJob(jobId);
+            }
+            jobValidTypeRepository.upsertJobValidType(jobId,validType);
+
+            return "Job " + jobId + " deleted from Elasticsearch and updated in RDB and ValidType.";
+
+        }catch (Exception e){
+            throw new RuntimeException("ValidTypeUpdate 및 삭제 실패 "+e.getMessage(),e);
+        }
+    }
 
     public List<ValidJobDto> findAllJobWithValidType() {
         List<Job> jobList = jobRepository.findAllWithValidType();

--- a/src/test/java/com/www/goodjob/controller/JobControllerTest.java
+++ b/src/test/java/com/www/goodjob/controller/JobControllerTest.java
@@ -1,0 +1,17 @@
+package com.www.goodjob.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JobControllerTest {
+
+    @Test
+    void deleteJobWithValidType() {
+
+        assertArrayEquals();
+    }
+
+    @Test
+
+}

--- a/src/test/java/com/www/goodjob/controller/JobControllerTest.java
+++ b/src/test/java/com/www/goodjob/controller/JobControllerTest.java
@@ -6,12 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class JobControllerTest {
 
-    @Test
-    void deleteJobWithValidType() {
 
-        assertArrayEquals();
-    }
 
-    @Test
 
 }

--- a/src/test/java/com/www/goodjob/service/JobServiceTest.java
+++ b/src/test/java/com/www/goodjob/service/JobServiceTest.java
@@ -1,5 +1,6 @@
 package com.www.goodjob.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.www.goodjob.domain.Job;
 import com.www.goodjob.domain.JobRegion;
 import com.www.goodjob.domain.Region;
@@ -7,6 +8,7 @@ import com.www.goodjob.domain.User;
 import com.www.goodjob.dto.JobDto;
 import com.www.goodjob.dto.RegionGroupDto;
 import com.www.goodjob.repository.JobRepository;
+import com.www.goodjob.repository.JobValidTypeRepository;
 import com.www.goodjob.repository.RegionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,6 +48,9 @@ class JobServiceTest {
 
     @Mock
     private RegionRepository regionRepository;
+
+    @Mock
+    private JobValidTypeRepository jobValidTypeRepository;
 
     @BeforeEach
     void setup() {
@@ -208,5 +213,33 @@ class JobServiceTest {
 
         assertTrue(thrown.getMessage().contains("FastAPI 요청 실패"));
         verify(restTemplate).delete(expectedUrl);
+    }
+
+    @Test
+    void deleteJobWithValidType_shouldNotDeleteWhenValidTypeIsZero() {
+        // given
+        Long jobId = 456L;
+        Integer validType = 0;
+        String expectedUrl = "http://localhost:8000/delete-job?job_id=456";
+
+        // when
+        jobService.deleteJobWithValidType(jobId, validType);
+
+        // then
+        verify(restTemplate, never()).delete(expectedUrl); // 삭제가 일어나지 않아야 함
+    }
+
+    @Test
+    void deleteJobWithValidType_shouldDeleteWhenValidTypeIsNotZero() {
+        // given
+        Long jobId = 456L;
+        Integer validType = 1;
+        String expectedUrl = "http://localhost:8000/delete-job?job_id=456";
+
+        // when
+        jobService.deleteJobWithValidType(jobId, validType);
+
+        // then
+        verify(restTemplate).delete(expectedUrl); // 삭제가 일어나야함
     }
 }


### PR DESCRIPTION
- ValidTypeDTO를 생성하고 API 두 개를 만들었습니다.

- /jobs/delete-one-job-valid-type  공고 삭제 

원래 delete-one-job 함수를 이용였고 , upsert를 같이 활용했습니다. 테스트 코드도 추가했습니다.

-/jobs/jobs/job-valid-type  공고 가져오기 

validType을 포함하는 모든 직군을 가져옵니다.