### PR TITLE
FIX: slow query problem search with Entity Graph

### DIFF
--- a/src/main/java/com/www/goodjob/domain/Job.java
+++ b/src/main/java/com/www/goodjob/domain/Job.java
@@ -9,6 +9,20 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@NamedEntityGraph(
+        name = "Job.withJobRegionsAndRegion",
+        attributeNodes = {
+                @NamedAttributeNode(value = "jobRegions", subgraph = "jobRegions-subgraph")
+        },
+        subgraphs = {
+                @NamedSubgraph(
+                        name = "jobRegions-subgraph",
+                        attributeNodes = {
+                                @NamedAttributeNode("region")
+                        }
+                )
+        }
+)
 @Entity
 @Table(name = "jobs")
 @Getter

--- a/src/main/java/com/www/goodjob/repository/JobRepository.java
+++ b/src/main/java/com/www/goodjob/repository/JobRepository.java
@@ -15,8 +15,6 @@ public interface JobRepository extends JpaRepository<Job, Long> {
 
     @Query(value = """
     SELECT DISTINCT j FROM Job j
-    LEFT JOIN FETCH j.jobRegions jr
-    LEFT JOIN FETCH jr.region r
     LEFT JOIN FETCH j.favicon f
     WHERE j.isPublic = true
     AND (
@@ -73,8 +71,50 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     )
     """
     )
+    @EntityGraph(value = "Job.withJobRegionsAndRegion")
     Page<Job> searchJobsWithFilters(
             @Param("keyword") String keyword,
+            @Param("jobTypes") List<String> jobTypes,
+            @Param("experiences") List<String> experiences,
+            @Param("sidos") List<String> sidos,
+            @Param("sigungus") List<String> sigungus,
+            Pageable pageable
+    );
+
+
+    @Query(value = """
+SELECT j FROM Job j
+WHERE j.isPublic = true
+AND (:jobTypes IS NULL OR j.jobType IN :jobTypes)
+AND (:experiences IS NULL OR j.experience IN :experiences)
+AND (
+    (:sidos IS NULL AND :sigungus IS NULL)
+    OR EXISTS (
+        SELECT 1 FROM JobRegion jr
+        WHERE jr.job = j
+        AND (:sidos IS NULL OR jr.region.sido IN :sidos)
+        AND (:sigungus IS NULL OR jr.region.sigungu IN :sigungus)
+    )
+)
+""",
+            countQuery = """
+SELECT COUNT(j.id) FROM Job j
+WHERE j.isPublic = true
+AND (:jobTypes IS NULL OR j.jobType IN :jobTypes)
+AND (:experiences IS NULL OR j.experience IN :experiences)
+AND (
+    (:sidos IS NULL AND :sigungus IS NULL)
+    OR EXISTS (
+        SELECT 1 FROM JobRegion jr
+        WHERE jr.job = j
+        AND (:sidos IS NULL OR jr.region.sido IN :sidos)
+        AND (:sigungus IS NULL OR jr.region.sigungu IN :sigungus)
+    )
+)
+"""
+    )
+    @EntityGraph(value = "Job.withJobRegionsAndRegion") // 이 부분을 추가!
+    Page<Job> searchJobsWithFiltersWithOutKeyword(
             @Param("jobTypes") List<String> jobTypes,
             @Param("experiences") List<String> experiences,
             @Param("sidos") List<String> sidos,

--- a/src/main/java/com/www/goodjob/service/JobService.java
+++ b/src/main/java/com/www/goodjob/service/JobService.java
@@ -197,14 +197,10 @@ public class JobService {
         List<String> safeSido = (sidoFilters == null || sidoFilters.isEmpty()) ? null : sidoFilters;
         List<String> safeSigungu = (sigunguFilters == null || sigunguFilters.isEmpty()) ? null : sigunguFilters;
 
-        Page<Job> jobPage = jobRepository.searchJobsWithFilters(
-                keyword,
-                safeJobTypes,
-                safeExperience,
-                safeSido,
-                safeSigungu,
-                pageable
-        );
+        Page<Job> jobPage = (keyword != null)
+                ? jobRepository.searchJobsWithFilters(keyword, safeJobTypes, safeExperience, safeSido, safeSigungu, pageable)
+                : jobRepository.searchJobsWithFiltersWithOutKeyword(safeJobTypes, safeExperience, safeSido, safeSigungu, pageable);
+
         return jobPage.map(JobWithValidTypeDto::from);
     }
 


### PR DESCRIPTION
![Screenshot 2025-06-13 at 3 01 25 AM](https://github.com/user-attachments/assets/fb2b3160-5136-4762-952b-ec921b946e67)

Entity Graph를 사용하여 기존의 Ditinct join fecth로 발생하는데 중복된 행을 불러오는 불필요한 행위를 제거했습니다.
EntityGraph를 사용하면 Join을 하지 않아도 연결된 region 데이터를 메모리에 저장했다가 , 필요시 불러옴으로써 N+1 문제도 발생하지 않습니디니다.
11초 --> 3초 정도로 개선