### PR TITLE
FIX: slow query searchfilter

### DIFF
--- a/src/main/java/com/www/goodjob/repository/JobRepository.java
+++ b/src/main/java/com/www/goodjob/repository/JobRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface JobRepository extends JpaRepository<Job, Long> {
 
     @Query(value = """
-    SELECT DISTINCT j FROM Job j
+    SELECT j FROM Job j
     LEFT JOIN FETCH j.favicon f
     WHERE j.isPublic = true
     AND (
@@ -34,7 +34,7 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     AND (
         (:sidos IS NULL AND :sigungus IS NULL)
         OR EXISTS (
-            SELECT 1 FROM JobRegion jr2
+            SELECT 1 FROM j.jobRegions jr2
             WHERE jr2.job = j
             AND (:sidos IS NULL OR jr2.region.sido IN :sidos)
             AND (:sigungus IS NULL OR jr2.region.sigungu IN :sigungus)
@@ -83,7 +83,14 @@ public interface JobRepository extends JpaRepository<Job, Long> {
 
 
     @Query(value = """
-SELECT j FROM Job j
+SELECT new com.www.goodjob.dto.JobWithValidTypeDto(j.id,
+                                                      j.companyName,
+                                                       j.title,
+                                                       j.jobValidType,
+                                                       j.isPublic,
+                                                       j.createdAt,
+                                                       j.applyEndDate,
+                                                       j.url) FROM Job j
 WHERE j.isPublic = true
 AND (:jobTypes IS NULL OR j.jobType IN :jobTypes)
 AND (:experiences IS NULL OR j.experience IN :experiences)
@@ -114,7 +121,7 @@ AND (
 """
     )
     @EntityGraph(value = "Job.withJobRegionsAndRegion") // 이 부분을 추가!
-    Page<Job> searchJobsWithFiltersWithOutKeyword(
+    Page<JobWithValidTypeDto> searchJobsWithFiltersWithOutKeyword(
             @Param("jobTypes") List<String> jobTypes,
             @Param("experiences") List<String> experiences,
             @Param("sidos") List<String> sidos,

--- a/src/main/java/com/www/goodjob/service/JobService.java
+++ b/src/main/java/com/www/goodjob/service/JobService.java
@@ -197,11 +197,13 @@ public class JobService {
         List<String> safeSido = (sidoFilters == null || sidoFilters.isEmpty()) ? null : sidoFilters;
         List<String> safeSigungu = (sigunguFilters == null || sigunguFilters.isEmpty()) ? null : sigunguFilters;
 
-        Page<Job> jobPage = (keyword != null)
-                ? jobRepository.searchJobsWithFilters(keyword, safeJobTypes, safeExperience, safeSido, safeSigungu, pageable)
-                : jobRepository.searchJobsWithFiltersWithOutKeyword(safeJobTypes, safeExperience, safeSido, safeSigungu, pageable);
+        if(keyword !=null) {
+            Page<Job> jobPage = jobRepository.searchJobsWithFilters(keyword, safeJobTypes, safeExperience, safeSido, safeSigungu, pageable);
+            return jobPage.map(JobWithValidTypeDto::from);
+        }
+        return jobRepository.searchJobsWithFiltersWithOutKeyword(safeJobTypes, safeExperience, safeSido, safeSigungu, pageable);
 
-        return jobPage.map(JobWithValidTypeDto::from);
+
     }
 
     @Transactional


### PR DESCRIPTION
<img width="706" alt="Screenshot 2025-06-13 at 9 36 20 AM" src="https://github.com/user-attachments/assets/c3ce0f4d-7962-4d9b-849e-7c5ce3082f61" />

1.프로젝션 코드를 썻습니다. 검색 기능을 구현할떄, raw_jobs_text를 가져오는

것이 매우 비효율적이라 판단.
(필드를 가져올떄 시간이 많이 걸리는듯)

2.job_region테이블에서 job_id, region_id 중복제거 했습니다.(테이블에 index추가)